### PR TITLE
feat: add PostHog analytics

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,11 +45,13 @@ There is an example configuration file available at [`config/config.sample.json`
 
 ### Analytics
 
-PostHog product analytics are wired through environment variables. They are no-ops when `POSTHOG_KEY` is empty (dev/CI/tests emit nothing). Three event types are emitted — all metadata only, no scraped content:
+PostHog product analytics are wired through environment variables. They are no-ops when `POSTHOG_KEY` is empty (dev/CI/tests emit nothing). The following events are emitted — all metadata only, no scraped content:
 
-- `scrape_run` — one per iteration: source name, items found/new, duration, success/error status.
-- `source_scraped` — one per source per iteration: source name, records added/total, duration, success/error.
-- Exception capture — uncaught exceptions: message and stack trace only (Node.js does not serialize frame-local variables).
+- `scrape_started` — emitted before each scraper iteration starts. Properties: `source`.
+- `scrape_run` — emitted after each scraper iteration succeeds or fails. Properties: `source`, `service`, `items_found`, `items_new`, `ms`, `status`.
+- `source_scraped` — emitted after each source scrape succeeds or fails. Properties: `source`, `records_added`, `records_total`, `duration_ms`, `success`.
+- `notification_sent` — emitted after a Discord notification batch succeeds or fails. Properties: `source`, `count`, `success`.
+- Exception capture — emitted for handled scraper errors via PostHog exception capture. Properties include `service`, `context`, and `scraper`; PostHog records the exception message and stack trace only (Node.js does not serialize frame-local variables).
 
 | Variable       | Default                      | Description                            |
 | -------------- | ---------------------------- | -------------------------------------- |

--- a/README.md
+++ b/README.md
@@ -45,7 +45,11 @@ There is an example configuration file available at [`config/config.sample.json`
 
 ### Analytics
 
-PostHog product analytics are wired through environment variables. They are no-ops when `POSTHOG_KEY` is empty (dev/CI/tests emit nothing). A `scrape_run` summary event (source, items found/new, duration, status) is sent per scrape iteration; no per-post events and no scraped content are sent.
+PostHog product analytics are wired through environment variables. They are no-ops when `POSTHOG_KEY` is empty (dev/CI/tests emit nothing). Three event types are emitted — all metadata only, no scraped content:
+
+- `scrape_run` — one per iteration: source name, items found/new, duration, success/error status.
+- `source_scraped` — one per source per iteration: source name, records added/total, duration, success/error.
+- Exception capture — uncaught exceptions: message and stack trace only (Node.js does not serialize frame-local variables).
 
 | Variable       | Default                      | Description                            |
 | -------------- | ---------------------------- | -------------------------------------- |

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ PostHog product analytics are wired through environment variables. They are no-o
 | `POSTHOG_KEY`  | _empty_                      | PostHog project ingest key (public).   |
 | `POSTHOG_HOST` | `https://eu.i.posthog.com`   | PostHog Cloud EU ingest host.          |
 
-The Compose files ship the public key as a default, so `docker compose up` reports out of the box.
+Analytics require an explicit `POSTHOG_KEY` in the environment; without it the scraper runs silently with no telemetry.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -43,6 +43,17 @@ You can select which scrapers to run declaratively (in the configuration with th
 
 There is an example configuration file available at [`config/config.sample.json`](./config/config.sample.json). Copy it to `config/config.json` and edit it to your liking.
 
+### Analytics
+
+PostHog product analytics are wired through environment variables. They are no-ops when `POSTHOG_KEY` is empty (dev/CI/tests emit nothing). A `scrape_run` summary event (source, items found/new, duration, status) is sent per scrape iteration; no per-post events and no scraped content are sent.
+
+| Variable       | Default                      | Description                            |
+| -------------- | ---------------------------- | -------------------------------------- |
+| `POSTHOG_KEY`  | _empty_                      | PostHog project ingest key (public).   |
+| `POSTHOG_HOST` | `https://eu.i.posthog.com`   | PostHog Cloud EU ingest host.          |
+
+The Compose files ship the public key as a default, so `docker compose up` reports out of the box.
+
 ## License
 
 This project is licensed under the terms of the MIT license.

--- a/compose.prod.yaml
+++ b/compose.prod.yaml
@@ -5,7 +5,7 @@ services:
     image: ghcr.io/finki-hub/services-scraper:latest
     restart: unless-stopped
     environment:
-      POSTHOG_KEY: ${POSTHOG_KEY:-phc_xXEqLMnYeDPuXA6HHwuasQMdSufDGryS8vZZuHmu9Qwd}
+      POSTHOG_KEY: ${POSTHOG_KEY:-}
       POSTHOG_HOST: ${POSTHOG_HOST:-https://eu.i.posthog.com}
     volumes:
       - ./cache:/app/cache

--- a/compose.prod.yaml
+++ b/compose.prod.yaml
@@ -4,6 +4,9 @@ services:
   scraper:
     image: ghcr.io/finki-hub/services-scraper:latest
     restart: unless-stopped
+    environment:
+      POSTHOG_KEY: ${POSTHOG_KEY:-phc_xXEqLMnYeDPuXA6HHwuasQMdSufDGryS8vZZuHmu9Qwd}
+      POSTHOG_HOST: ${POSTHOG_HOST:-https://eu.i.posthog.com}
     volumes:
       - ./cache:/app/cache
       - ./config:/app/config

--- a/compose.yaml
+++ b/compose.yaml
@@ -5,6 +5,9 @@ services:
     build: .
     image: services-scraper-dev:latest
     restart: unless-stopped
+    environment:
+      POSTHOG_KEY: ${POSTHOG_KEY:-phc_xXEqLMnYeDPuXA6HHwuasQMdSufDGryS8vZZuHmu9Qwd}
+      POSTHOG_HOST: ${POSTHOG_HOST:-https://eu.i.posthog.com}
     volumes:
       - ./cache:/app/cache
       - ./config:/app/config

--- a/compose.yaml
+++ b/compose.yaml
@@ -6,7 +6,7 @@ services:
     image: services-scraper-dev:latest
     restart: unless-stopped
     environment:
-      POSTHOG_KEY: ${POSTHOG_KEY:-phc_xXEqLMnYeDPuXA6HHwuasQMdSufDGryS8vZZuHmu9Qwd}
+      POSTHOG_KEY: ${POSTHOG_KEY:-}
       POSTHOG_HOST: ${POSTHOG_HOST:-https://eu.i.posthog.com}
     volumes:
       - ./cache:/app/cache

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -19,6 +19,7 @@ const config = [
     rules: {
       '@typescript-eslint/restrict-template-expressions': ['off'],
       'class-methods-use-this': ['off'],
+      'no-empty': ['error', { allowEmptyCatch: true }],
     },
   },
 ];

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "finki-auth": "^2.0.1",
         "pino": "^10.3.1",
         "pino-pretty": "^13.1.3",
+        "posthog-node": "^5.38.6",
         "zod": "^4.4.3"
       },
       "devDependencies": {
@@ -1485,6 +1486,21 @@
       "funding": {
         "url": "https://opencollective.com/pkgr"
       }
+    },
+    "node_modules/@posthog/core": {
+      "version": "1.38.0",
+      "resolved": "https://registry.npmjs.org/@posthog/core/-/core-1.38.0.tgz",
+      "integrity": "sha512-QLrJh0hMVpEJXHNyiJR9YhvIO5tzLDedw4UHdvB+ub4fXHMtHCA8H44qgl11HWR3ajpjxtJ8hs3HyOGVF3Zc1w==",
+      "license": "MIT",
+      "dependencies": {
+        "@posthog/types": "^1.391.1"
+      }
+    },
+    "node_modules/@posthog/types": {
+      "version": "1.391.1",
+      "resolved": "https://registry.npmjs.org/@posthog/types/-/types-1.391.1.tgz",
+      "integrity": "sha512-ASwd7Nf4pViqdYRYaNRyPYRVKWa1CcHUAUWR0XeQJLGdNnsWACBwe0sSieb/cHnKsRXjRwO/23KIY83lm/Ccpw==",
+      "license": "MIT"
     },
     "node_modules/@rolldown/binding-android-arm64": {
       "version": "1.0.1",
@@ -7251,6 +7267,26 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/posthog-node": {
+      "version": "5.38.6",
+      "resolved": "https://registry.npmjs.org/posthog-node/-/posthog-node-5.38.6.tgz",
+      "integrity": "sha512-Sm2mCAa9/lTTYppnKyy0AhQrriq8fOd8B2vwd3EE/9uihyIx9qkJ1xGYbvADxQJlF7HqM1/TIFCKsI0JvF8gjQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@posthog/core": "^1.38.0"
+      },
+      "engines": {
+        "node": "^20.20.0 || >=22.22.0"
+      },
+      "peerDependencies": {
+        "rxjs": "^7.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rxjs": {
+          "optional": true
+        }
       }
     },
     "node_modules/prelude-ls": {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "finki-auth": "^2.0.1",
     "pino": "^10.3.1",
     "pino-pretty": "^13.1.3",
+    "posthog-node": "^5.38.6",
     "zod": "^4.4.3"
   },
   "description": "FINKI Scraper",

--- a/src/Scraper.ts
+++ b/src/Scraper.ts
@@ -17,7 +17,9 @@ import {
 } from './lib/Scraper.js';
 import {
   captureException,
+  captureNotificationSent,
   captureScrapeRun,
+  captureScrapeStarted,
   captureSourceScraped,
 } from './utils/analytics.js';
 import { createMentionComponent, truncateString } from './utils/components.js';
@@ -71,6 +73,7 @@ export class Scraper {
   public async run(): Promise<void> {
     while (true) {
       this.logger.info(`[${this.scraperName}] ${LOG_MESSAGES.searching}`);
+      captureScrapeStarted({ source: this.scraperName });
 
       try {
         await this.validateCookie();
@@ -204,8 +207,22 @@ export class Scraper {
     const sendPosts = getConfigProperty('sendPosts');
 
     if (sendPosts) {
-      await this.sendBatch(posts.map((post) => post.component));
-      logger.info(`[${this.scraperName}] ${LOG_MESSAGES.sentNewPosts}`);
+      try {
+        await this.sendBatch(posts.map((post) => post.component));
+        captureNotificationSent({
+          count: posts.length,
+          source: this.scraperName,
+          success: true,
+        });
+        logger.info(`[${this.scraperName}] ${LOG_MESSAGES.sentNewPosts}`);
+      } catch (error) {
+        captureNotificationSent({
+          count: posts.length,
+          source: this.scraperName,
+          success: false,
+        });
+        throw error;
+      }
     }
 
     commit();

--- a/src/Scraper.ts
+++ b/src/Scraper.ts
@@ -11,7 +11,7 @@ import { type Logger } from 'pino';
 
 import { getConfigProperty } from './configuration/config.js';
 import { type ScraperConfig, type ScraperStrategy } from './lib/Scraper.js';
-import { captureScrapeRun } from './utils/analytics.js';
+import { captureException, captureScrapeRun } from './utils/analytics.js';
 import { createMentionComponent, truncateString } from './utils/components.js';
 import { ERROR_MESSAGES, LOG_MESSAGES } from './utils/constants.js';
 import { extractErrorCauses } from './utils/error-causes.js';
@@ -182,6 +182,11 @@ export class Scraper {
     context?: string,
     code?: string,
   ): Promise<void> {
+    captureException(error, {
+      context,
+      scraper: this.scraperName,
+    });
+
     let errorMessage: string;
     let stackTrace: string | undefined;
 

--- a/src/Scraper.ts
+++ b/src/Scraper.ts
@@ -10,8 +10,16 @@ import { setTimeout } from 'node:timers/promises';
 import { type Logger } from 'pino';
 
 import { getConfigProperty } from './configuration/config.js';
-import { type ScraperConfig, type ScraperStrategy } from './lib/Scraper.js';
-import { captureException, captureScrapeRun } from './utils/analytics.js';
+import {
+  type ScraperConfig,
+  type ScraperStrategy,
+  type StrategyResult,
+} from './lib/Scraper.js';
+import {
+  captureException,
+  captureScrapeRun,
+  captureSourceScraped,
+} from './utils/analytics.js';
 import { createMentionComponent, truncateString } from './utils/components.js';
 import { ERROR_MESSAGES, LOG_MESSAGES } from './utils/constants.js';
 import { extractErrorCauses } from './utils/error-causes.js';
@@ -141,11 +149,39 @@ export class Scraper {
     const maxPosts =
       this.scraperConfig.maxPosts ?? getConfigProperty('maxPosts');
 
-    const { commit, itemsFound, posts } = await this.strategy.getChanges({
-      cookie: this.cookie,
-      link: this.scraperConfig.link,
-      maxPosts,
-      scraperId: this.scraperName,
+    const scrapeStart = performance.now();
+    let strategyResult: StrategyResult;
+
+    try {
+      strategyResult = await this.strategy.getChanges({
+        cookie: this.cookie,
+        link: this.scraperConfig.link,
+        maxPosts,
+        scraperId: this.scraperName,
+      });
+    } catch (error) {
+      captureSourceScraped({
+        durationMs: Math.round(performance.now() - scrapeStart),
+        recordsAdded: null,
+        recordsChanged: null,
+        recordsRemoved: null,
+        recordsTotal: null,
+        source: this.scraperName,
+        success: false,
+      });
+      throw error;
+    }
+
+    const { commit, itemsFound, posts } = strategyResult;
+
+    captureSourceScraped({
+      durationMs: Math.round(performance.now() - scrapeStart),
+      recordsAdded: posts.length,
+      recordsChanged: null,
+      recordsRemoved: null,
+      recordsTotal: itemsFound ?? posts.length,
+      source: this.scraperName,
+      success: true,
     });
 
     const summary = {

--- a/src/Scraper.ts
+++ b/src/Scraper.ts
@@ -166,8 +166,6 @@ export class Scraper {
       captureSourceScraped({
         durationMs: Math.round(performance.now() - scrapeStart),
         recordsAdded: null,
-        recordsChanged: null,
-        recordsRemoved: null,
         recordsTotal: null,
         source: this.scraperName,
         success: false,
@@ -180,8 +178,6 @@ export class Scraper {
     captureSourceScraped({
       durationMs: Math.round(performance.now() - scrapeStart),
       recordsAdded: posts.length,
-      recordsChanged: null,
-      recordsRemoved: null,
       recordsTotal: itemsFound ?? posts.length,
       source: this.scraperName,
       success: true,

--- a/src/Scraper.ts
+++ b/src/Scraper.ts
@@ -11,6 +11,7 @@ import { type Logger } from 'pino';
 
 import { getConfigProperty } from './configuration/config.js';
 import { type ScraperConfig, type ScraperStrategy } from './lib/Scraper.js';
+import { captureScrapeRun } from './utils/analytics.js';
 import { createMentionComponent, truncateString } from './utils/components.js';
 import { ERROR_MESSAGES, LOG_MESSAGES } from './utils/constants.js';
 import { extractErrorCauses } from './utils/error-causes.js';
@@ -73,9 +74,25 @@ export class Scraper {
         continue;
       }
 
+      const start = performance.now();
+
       try {
-        await this.getAndSendPosts();
+        const { itemsFound, itemsNew } = await this.getAndSendPosts();
+        captureScrapeRun({
+          itemsFound,
+          itemsNew,
+          ms: Math.round(performance.now() - start),
+          source: this.scraperName,
+          status: 'success',
+        });
       } catch (error) {
+        captureScrapeRun({
+          itemsFound: 0,
+          itemsNew: 0,
+          ms: Math.round(performance.now() - start),
+          source: this.scraperName,
+          status: 'error',
+        });
         await this.handleError(error, 'while fetching and sending posts');
         await Scraper.sleep(getConfigProperty('errorDelay'));
 
@@ -108,7 +125,10 @@ export class Scraper {
     }
   }
 
-  private async getAndSendPosts(): Promise<void> {
+  private async getAndSendPosts(): Promise<{
+    itemsFound: number;
+    itemsNew: number;
+  }> {
     if (this.cookie === undefined && this.strategy.getCookie !== undefined) {
       try {
         this.cookie = await this.strategy.getCookie();
@@ -121,17 +141,22 @@ export class Scraper {
     const maxPosts =
       this.scraperConfig.maxPosts ?? getConfigProperty('maxPosts');
 
-    const { commit, posts } = await this.strategy.getChanges({
+    const { commit, itemsFound, posts } = await this.strategy.getChanges({
       cookie: this.cookie,
       link: this.scraperConfig.link,
       maxPosts,
       scraperId: this.scraperName,
     });
 
+    const summary = {
+      itemsFound: itemsFound ?? posts.length,
+      itemsNew: posts.length,
+    };
+
     if (posts.length === 0) {
       this.logger.info(`[${this.scraperName}] ${LOG_MESSAGES.noNewPosts}`);
 
-      return;
+      return summary;
     }
 
     for (const post of posts) {
@@ -148,6 +173,8 @@ export class Scraper {
     }
 
     commit();
+
+    return summary;
   }
 
   private async handleError(

--- a/src/lib/Scraper.ts
+++ b/src/lib/Scraper.ts
@@ -49,6 +49,7 @@ export type StrategyContext = {
 
 export type StrategyResult = {
   commit: () => void;
+  itemsFound?: number;
   posts: PostData[];
 };
 

--- a/src/strategies/base/HtmlStrategy.ts
+++ b/src/strategies/base/HtmlStrategy.ts
@@ -49,7 +49,7 @@ export abstract class HtmlStrategy implements ScraperStrategy {
     const allIds = posts.map((post) => this.getId($(post)));
 
     if (allIds.every((id) => id === null || seenIds.has(id))) {
-      return NO_CHANGES;
+      return { ...NO_CHANGES, itemsFound: posts.length };
     }
 
     const newPosts: PostData[] = [];
@@ -76,6 +76,7 @@ export abstract class HtmlStrategy implements ScraperStrategy {
       commit: () => {
         markPostsSeen(context.scraperId, allIds);
       },
+      itemsFound: posts.length,
       posts: newPosts,
     };
   }

--- a/src/utils/analytics.ts
+++ b/src/utils/analytics.ts
@@ -45,6 +45,20 @@ export const captureScrapeRun = (event: ScrapeRunEvent): void => {
   });
 };
 
+export const captureException = (
+  error: unknown,
+  properties?: Record<string, unknown>,
+): void => {
+  try {
+    client?.captureException(error, SERVICE_NAME, {
+      service: SERVICE_NAME,
+      ...properties,
+    });
+  } catch {
+    // no-op: analytics must never throw
+  }
+};
+
 export const shutdownAnalytics = async (): Promise<void> => {
   if (client === undefined) {
     return;

--- a/src/utils/analytics.ts
+++ b/src/utils/analytics.ts
@@ -56,9 +56,7 @@ export const captureSourceScraped = (event: SourceScrapedEvent): void => {
         success: event.success,
       },
     });
-  } catch {
-    // no-op: analytics must never throw
-  }
+  } catch {}
 };
 
 export const captureScrapeRun = (event: ScrapeRunEvent): void => {
@@ -77,9 +75,7 @@ export const captureScrapeRun = (event: ScrapeRunEvent): void => {
         status: event.status,
       },
     });
-  } catch {
-    // no-op: analytics must never throw
-  }
+  } catch {}
 };
 
 export const captureException = (
@@ -91,9 +87,7 @@ export const captureException = (
       service: SERVICE_NAME,
       ...properties,
     });
-  } catch {
-    // no-op: analytics must never throw
-  }
+  } catch {}
 };
 
 const SHUTDOWN_TIMEOUT_MS = 2_000;

--- a/src/utils/analytics.ts
+++ b/src/utils/analytics.ts
@@ -39,38 +39,46 @@ export type SourceScrapedEvent = {
 };
 
 export const captureSourceScraped = (event: SourceScrapedEvent): void => {
-  client?.capture({
-    distinctId: SERVICE_NAME,
-    event: 'source_scraped',
-    properties: {
-      /* eslint-disable camelcase -- PostHog event properties use snake_case */
-      duration_ms: event.durationMs,
-      records_added: event.recordsAdded,
-      records_changed: event.recordsChanged,
-      records_removed: event.recordsRemoved,
-      records_total: event.recordsTotal,
-      /* eslint-enable camelcase -- PostHog event properties use snake_case */
-      source: event.source,
-      success: event.success,
-    },
-  });
+  try {
+    client?.capture({
+      distinctId: SERVICE_NAME,
+      event: 'source_scraped',
+      properties: {
+        /* eslint-disable camelcase -- PostHog event properties use snake_case */
+        duration_ms: event.durationMs,
+        records_added: event.recordsAdded,
+        records_changed: event.recordsChanged,
+        records_removed: event.recordsRemoved,
+        records_total: event.recordsTotal,
+        /* eslint-enable camelcase -- PostHog event properties use snake_case */
+        source: event.source,
+        success: event.success,
+      },
+    });
+  } catch {
+    // no-op: analytics must never throw
+  }
 };
 
 export const captureScrapeRun = (event: ScrapeRunEvent): void => {
-  client?.capture({
-    distinctId: SERVICE_NAME,
-    event: 'scrape_run',
-    properties: {
-      /* eslint-disable camelcase -- PostHog event properties use snake_case */
-      items_found: event.itemsFound,
-      items_new: event.itemsNew,
-      /* eslint-enable camelcase -- PostHog event properties use snake_case */
-      ms: event.ms,
-      service: SERVICE_NAME,
-      source: event.source,
-      status: event.status,
-    },
-  });
+  try {
+    client?.capture({
+      distinctId: SERVICE_NAME,
+      event: 'scrape_run',
+      properties: {
+        /* eslint-disable camelcase -- PostHog event properties use snake_case */
+        items_found: event.itemsFound,
+        items_new: event.itemsNew,
+        /* eslint-enable camelcase -- PostHog event properties use snake_case */
+        ms: event.ms,
+        service: SERVICE_NAME,
+        source: event.source,
+        status: event.status,
+      },
+    });
+  } catch {
+    // no-op: analytics must never throw
+  }
 };
 
 export const captureException = (

--- a/src/utils/analytics.ts
+++ b/src/utils/analytics.ts
@@ -28,6 +28,34 @@ export type ScrapeRunEvent = {
 
 export type ScrapeRunStatus = 'error' | 'success';
 
+export type SourceScrapedEvent = {
+  durationMs: number;
+  recordsAdded: null | number;
+  recordsChanged: null | number;
+  recordsRemoved: null | number;
+  recordsTotal: null | number;
+  source: string;
+  success: boolean;
+};
+
+export const captureSourceScraped = (event: SourceScrapedEvent): void => {
+  client?.capture({
+    distinctId: SERVICE_NAME,
+    event: 'source_scraped',
+    properties: {
+      /* eslint-disable camelcase -- PostHog event properties use snake_case */
+      duration_ms: event.durationMs,
+      records_added: event.recordsAdded,
+      records_changed: event.recordsChanged,
+      records_removed: event.recordsRemoved,
+      records_total: event.recordsTotal,
+      /* eslint-enable camelcase -- PostHog event properties use snake_case */
+      source: event.source,
+      success: event.success,
+    },
+  });
+};
+
 export const captureScrapeRun = (event: ScrapeRunEvent): void => {
   client?.capture({
     distinctId: SERVICE_NAME,

--- a/src/utils/analytics.ts
+++ b/src/utils/analytics.ts
@@ -12,7 +12,7 @@ const client =
     ? undefined
     : new PostHog(POSTHOG_KEY, {
         disableGeoip: true,
-        enableExceptionAutocapture: false,
+        enableExceptionAutocapture: true,
         flushAt: 1,
         flushInterval: 0,
         host: POSTHOG_HOST,

--- a/src/utils/analytics.ts
+++ b/src/utils/analytics.ts
@@ -42,8 +42,6 @@ export type ScrapeStartedEvent = {
 export type SourceScrapedEvent = {
   durationMs: number;
   recordsAdded: null | number;
-  recordsChanged: null | number;
-  recordsRemoved: null | number;
   recordsTotal: null | number;
   source: string;
   success: boolean;
@@ -84,8 +82,6 @@ export const captureSourceScraped = (event: SourceScrapedEvent): void => {
         /* eslint-disable camelcase -- PostHog event properties use snake_case */
         duration_ms: event.durationMs,
         records_added: event.recordsAdded,
-        records_changed: event.recordsChanged,
-        records_removed: event.recordsRemoved,
         records_total: event.recordsTotal,
         /* eslint-enable camelcase -- PostHog event properties use snake_case */
         source: event.source,

--- a/src/utils/analytics.ts
+++ b/src/utils/analytics.ts
@@ -1,3 +1,4 @@
+import { setTimeout } from 'node:timers/promises';
 import { PostHog } from 'posthog-node';
 
 import { logger } from './logger.js';
@@ -95,13 +96,15 @@ export const captureException = (
   }
 };
 
+const SHUTDOWN_TIMEOUT_MS = 2_000;
+
 export const shutdownAnalytics = async (): Promise<void> => {
   if (client === undefined) {
     return;
   }
 
   try {
-    await client.shutdown();
+    await Promise.race([client.shutdown(), setTimeout(SHUTDOWN_TIMEOUT_MS)]);
   } catch (error) {
     logger.error({ error }, 'Failed to flush PostHog analytics');
   }

--- a/src/utils/analytics.ts
+++ b/src/utils/analytics.ts
@@ -1,0 +1,58 @@
+import { PostHog } from 'posthog-node';
+
+import { logger } from './logger.js';
+
+const SERVICE_NAME = 'services-scraper';
+
+const POSTHOG_KEY = process.env['POSTHOG_KEY'] ?? '';
+const POSTHOG_HOST = process.env['POSTHOG_HOST'] ?? 'https://eu.i.posthog.com';
+
+const client =
+  POSTHOG_KEY === ''
+    ? undefined
+    : new PostHog(POSTHOG_KEY, {
+        disableGeoip: true,
+        enableExceptionAutocapture: false,
+        flushAt: 1,
+        flushInterval: 0,
+        host: POSTHOG_HOST,
+      });
+
+export type ScrapeRunEvent = {
+  itemsFound: number;
+  itemsNew: number;
+  ms: number;
+  source: string;
+  status: ScrapeRunStatus;
+};
+
+export type ScrapeRunStatus = 'error' | 'success';
+
+export const captureScrapeRun = (event: ScrapeRunEvent): void => {
+  client?.capture({
+    distinctId: SERVICE_NAME,
+    event: 'scrape_run',
+    properties: {
+      /* eslint-disable camelcase -- PostHog event properties use snake_case */
+      items_found: event.itemsFound,
+      items_new: event.itemsNew,
+      /* eslint-enable camelcase -- PostHog event properties use snake_case */
+      ms: event.ms,
+      service: SERVICE_NAME,
+      source: event.source,
+      status: event.status,
+    },
+  });
+};
+
+export const shutdownAnalytics = async (): Promise<void> => {
+  if (client === undefined) {
+    return;
+  }
+
+  try {
+    await client.shutdown();
+  } catch (error) {
+    logger.error({ error }, 'Failed to flush PostHog analytics');
+  }
+};

--- a/src/utils/analytics.ts
+++ b/src/utils/analytics.ts
@@ -19,6 +19,12 @@ const client =
         host: POSTHOG_HOST,
       });
 
+export type NotificationSentEvent = {
+  count: number;
+  source: string;
+  success: boolean;
+};
+
 export type ScrapeRunEvent = {
   itemsFound: number;
   itemsNew: number;
@@ -29,6 +35,10 @@ export type ScrapeRunEvent = {
 
 export type ScrapeRunStatus = 'error' | 'success';
 
+export type ScrapeStartedEvent = {
+  source: string;
+};
+
 export type SourceScrapedEvent = {
   durationMs: number;
   recordsAdded: null | number;
@@ -37,6 +47,32 @@ export type SourceScrapedEvent = {
   recordsTotal: null | number;
   source: string;
   success: boolean;
+};
+
+export const captureScrapeStarted = (event: ScrapeStartedEvent): void => {
+  try {
+    client?.capture({
+      distinctId: SERVICE_NAME,
+      event: 'scrape_started',
+      properties: {
+        source: event.source,
+      },
+    });
+  } catch {}
+};
+
+export const captureNotificationSent = (event: NotificationSentEvent): void => {
+  try {
+    client?.capture({
+      distinctId: SERVICE_NAME,
+      event: 'notification_sent',
+      properties: {
+        count: event.count,
+        source: event.source,
+        success: event.success,
+      },
+    });
+  } catch {}
 };
 
 export const captureSourceScraped = (event: SourceScrapedEvent): void => {

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -1,4 +1,4 @@
-import { shutdownAnalytics } from './analytics.js';
+import { captureException, shutdownAnalytics } from './analytics.js';
 import { closeCache } from './cache.js';
 import { logger } from './logger.js';
 import { errorWebhook } from './webhooks.js';
@@ -22,6 +22,12 @@ export const registerGlobalErrorHandlers = () => {
 
   process.on('unhandledRejection', async (reason) => {
     logger.error({ reason }, 'Unhandled Promise Rejection');
+    captureException(
+      reason instanceof Error ? reason : new Error(String(reason)),
+      {
+        handler: 'unhandledRejection',
+      },
+    );
 
     const msg =
       `❌ **Unhandled Promise Rejection (global)**\n` +
@@ -37,6 +43,7 @@ export const registerGlobalErrorHandlers = () => {
 
   process.on('uncaughtException', async (err) => {
     logger.error({ err }, 'Uncaught Exception');
+    captureException(err, { handler: 'uncaughtException' });
 
     const msg =
       `🚨 **Uncaught Exception (global)**\n` +

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -7,10 +7,13 @@ export const registerGlobalErrorHandlers = () => {
   const handleShutdown = async (signal: string) => {
     logger.info(`Received ${signal}, shutting down gracefully`);
     closeCache();
-    await shutdownAnalytics();
 
-    // eslint-disable-next-line n/no-process-exit, unicorn/no-process-exit -- Must exit to stop infinite scraper loops and pending timers
-    process.exit(0);
+    try {
+      await shutdownAnalytics();
+    } finally {
+      // eslint-disable-next-line n/no-process-exit, unicorn/no-process-exit -- Must exit to stop infinite scraper loops and pending timers
+      process.exit(0);
+    }
   };
 
   process.on('SIGTERM', () => {
@@ -50,9 +53,12 @@ export const registerGlobalErrorHandlers = () => {
     }
 
     closeCache();
-    await shutdownAnalytics();
 
-    // eslint-disable-next-line n/no-process-exit -- Must exit on uncaught exception to prevent undefined state
-    process.exit(1);
+    try {
+      await shutdownAnalytics();
+    } finally {
+      // eslint-disable-next-line n/no-process-exit -- Must exit on uncaught exception to prevent undefined state
+      process.exit(1);
+    }
   });
 };

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -1,4 +1,4 @@
-import { captureException, shutdownAnalytics } from './analytics.js';
+import { shutdownAnalytics } from './analytics.js';
 import { closeCache } from './cache.js';
 import { logger } from './logger.js';
 import { errorWebhook } from './webhooks.js';
@@ -22,12 +22,6 @@ export const registerGlobalErrorHandlers = () => {
 
   process.on('unhandledRejection', async (reason) => {
     logger.error({ reason }, 'Unhandled Promise Rejection');
-    captureException(
-      reason instanceof Error ? reason : new Error(String(reason)),
-      {
-        handler: 'unhandledRejection',
-      },
-    );
 
     const msg =
       `❌ **Unhandled Promise Rejection (global)**\n` +
@@ -43,7 +37,6 @@ export const registerGlobalErrorHandlers = () => {
 
   process.on('uncaughtException', async (err) => {
     logger.error({ err }, 'Uncaught Exception');
-    captureException(err, { handler: 'uncaughtException' });
 
     const msg =
       `🚨 **Uncaught Exception (global)**\n` +

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -1,21 +1,23 @@
+import { shutdownAnalytics } from './analytics.js';
 import { closeCache } from './cache.js';
 import { logger } from './logger.js';
 import { errorWebhook } from './webhooks.js';
 
 export const registerGlobalErrorHandlers = () => {
-  const handleShutdown = (signal: string) => {
+  const handleShutdown = async (signal: string) => {
     logger.info(`Received ${signal}, shutting down gracefully`);
     closeCache();
+    await shutdownAnalytics();
 
     // eslint-disable-next-line n/no-process-exit, unicorn/no-process-exit -- Must exit to stop infinite scraper loops and pending timers
     process.exit(0);
   };
 
   process.on('SIGTERM', () => {
-    handleShutdown('SIGTERM');
+    void handleShutdown('SIGTERM');
   });
   process.on('SIGINT', () => {
-    handleShutdown('SIGINT');
+    void handleShutdown('SIGINT');
   });
 
   process.on('unhandledRejection', async (reason) => {
@@ -48,6 +50,7 @@ export const registerGlobalErrorHandlers = () => {
     }
 
     closeCache();
+    await shutdownAnalytics();
 
     // eslint-disable-next-line n/no-process-exit -- Must exit on uncaught exception to prevent undefined state
     process.exit(1);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -23,6 +23,7 @@
     "noUnusedParameters": true,
     "outDir": "dist",
     "resolveJsonModule": true,
+    "skipLibCheck": true,
     "strict": true,
     "target": "ESNext"
   },


### PR DESCRIPTION
Adds PostHog (EU Cloud) `scrape_run` summary events (source, items_found, items_new, ms, status) — metadata-only, flush-on-exit. No per-item events (volume). tsc/eslint/build/54 tests pass.