### PR TITLE
fix: migrate FINKI scrapers to WordPress REST API

### DIFF
--- a/config/config.sample.json
+++ b/config/config.sample.json
@@ -12,7 +12,7 @@
   "scrapers": {
     "announcements": {
       "strategy": "announcements",
-      "link": "https://www.finki.ukim.mk/mk/student-announcement",
+      "link": "https://finki.ukim.mk/wp-json/wp/v2/announcement",
       "name": "Огласна табла",
       "role": "1333926602739810427",
       "webhook": "your_announcement_webhook",
@@ -20,7 +20,7 @@
     },
     "jobs": {
       "strategy": "jobs",
-      "link": "https://www.finki.ukim.mk/mk/fcse-jobs-internships",
+      "link": "https://finki.ukim.mk/wp-json/wp/v2/jobs-and-internships",
       "name": "Огласи",
       "webhook": "your_jobs_webhook",
       "enabled": true
@@ -34,13 +34,13 @@
     },
     "events": {
       "strategy": "events",
-      "link": "https://finki.ukim.mk/mk/fcse-events",
+      "link": "https://finki.ukim.mk/wp-json/wp/v2/event",
       "name": "Настани",
       "enabled": false
     },
     "projects": {
       "strategy": "projects",
-      "link": "https://finki.ukim.mk/mk/fcse-projects",
+      "link": "https://finki.ukim.mk/wp-json/wp/v2/project",
       "name": "Проекти",
       "enabled": false
     },
@@ -76,7 +76,7 @@
     },
     "timetables": {
       "strategy": "timetables",
-      "link": "https://www.finki.ukim.mk/mk/student-announcement",
+      "link": "https://finki.ukim.mk/wp-json/wp/v2/schedule",
       "name": "Распореди",
       "enabled": false
     },

--- a/src/Scraper.ts
+++ b/src/Scraper.ts
@@ -190,6 +190,7 @@ export class Scraper {
 
     if (posts.length === 0) {
       this.logger.info(`[${this.scraperName}] ${LOG_MESSAGES.noNewPosts}`);
+      commit();
 
       return summary;
     }

--- a/src/strategies/AnnouncementsStrategy.ts
+++ b/src/strategies/AnnouncementsStrategy.ts
@@ -1,34 +1,7 @@
-import type { Cheerio } from 'cheerio';
+import { WordPressStrategy } from './base/WordPressStrategy.js';
 
-import { ContainerBuilder, heading, hyperlink } from 'discord.js';
-import { type Element } from 'domhandler';
+export class AnnouncementsStrategy extends WordPressStrategy {
+  public collection = 'announcement';
 
-import type { PostData } from '../lib/Post.js';
-
-import { truncateString } from '../utils/components.js';
-import { FinkiNewsStrategy } from './base/FinkiNewsStrategy.js';
-
-export class AnnouncementsStrategy extends FinkiNewsStrategy {
-  public override idsSelector = 'a';
-
-  public override postsSelector = 'div.views-row';
-
-  public override getPostData($element: Cheerio<Element>): PostData {
-    const url = $element.find('a').attr('href')?.trim();
-    const link = url === undefined ? null : `https://finki.ukim.mk${url}`;
-
-    const title = truncateString($element.find('a').text().trim() || '?');
-
-    const component = new ContainerBuilder().addTextDisplayComponents(
-      (textDisplayComponent) =>
-        textDisplayComponent.setContent(
-          heading(link === null ? title : hyperlink(title, link), 2),
-        ),
-    );
-
-    return {
-      component,
-      id: this.getId($element),
-    };
-  }
+  public override includeContent = false;
 }

--- a/src/strategies/EventsStrategy.ts
+++ b/src/strategies/EventsStrategy.ts
@@ -1,5 +1,5 @@
-import { FinkiNewsStrategy } from './base/FinkiNewsStrategy.js';
+import { WordPressStrategy } from './base/WordPressStrategy.js';
 
-export class EventsStrategy extends FinkiNewsStrategy {
-  public postsSelector = 'div.news-item';
+export class EventsStrategy extends WordPressStrategy {
+  public collection = 'event';
 }

--- a/src/strategies/JobsStrategy.ts
+++ b/src/strategies/JobsStrategy.ts
@@ -1,5 +1,5 @@
-import { FinkiNewsStrategy } from './base/FinkiNewsStrategy.js';
+import { WordPressStrategy } from './base/WordPressStrategy.js';
 
-export class JobsStrategy extends FinkiNewsStrategy {
-  public postsSelector = 'div.views-row';
+export class JobsStrategy extends WordPressStrategy {
+  public collection = 'jobs-and-internships';
 }

--- a/src/strategies/ProjectsStrategy.ts
+++ b/src/strategies/ProjectsStrategy.ts
@@ -1,5 +1,5 @@
-import { FinkiNewsStrategy } from './base/FinkiNewsStrategy.js';
+import { WordPressStrategy } from './base/WordPressStrategy.js';
 
-export class ProjectsStrategy extends FinkiNewsStrategy {
-  public postsSelector = 'div.news-item';
+export class ProjectsStrategy extends WordPressStrategy {
+  public collection = 'project';
 }

--- a/src/strategies/TimetablesStrategy.ts
+++ b/src/strategies/TimetablesStrategy.ts
@@ -1,48 +1,7 @@
-import type { Cheerio } from 'cheerio';
-import type { Element } from 'domhandler';
+import { WordPressStrategy } from './base/WordPressStrategy.js';
 
-import { ContainerBuilder, heading, hyperlink } from 'discord.js';
+export class TimetablesStrategy extends WordPressStrategy {
+  public collection = 'schedule';
 
-import type { PostData } from '../lib/Post.js';
-
-import { truncateString } from '../utils/components.js';
-import { normalizeURL } from '../utils/links.js';
-import { HtmlStrategy } from './base/HtmlStrategy.js';
-
-export class TimetablesStrategy extends HtmlStrategy {
-  public idsSelector = 'a';
-
-  public postsSelector = 'div.col-sm-11';
-
-  public getId($element: Cheerio<Element>): null | string {
-    const id = $element
-      .find(this.idsSelector)
-      .text()
-      .replaceAll(/\s+/gu, ' ')
-      .trim();
-
-    return id === '' ? null : id;
-  }
-
-  public getPostData($element: Cheerio<Element>): PostData {
-    const url = $element.find('a').attr('href')?.trim();
-    const link =
-      url === undefined ? null : normalizeURL(url, 'https://finki.ukim.mk');
-
-    const title = truncateString(
-      $element.find('a').text().replaceAll(/\s+/gu, ' ').trim() || '?',
-    );
-
-    const component = new ContainerBuilder().addTextDisplayComponents(
-      (textDisplayComponent) =>
-        textDisplayComponent.setContent(
-          heading(link === null ? title : hyperlink(title, link), 2),
-        ),
-    );
-
-    return {
-      component,
-      id: this.getId($element),
-    };
-  }
+  public override includeContent = false;
 }

--- a/src/strategies/base/WordPressStrategy.ts
+++ b/src/strategies/base/WordPressStrategy.ts
@@ -1,6 +1,7 @@
 import * as cheerio from 'cheerio';
 import {
   ContainerBuilder,
+  escapeMarkdown,
   heading,
   hyperlink,
   TextDisplayBuilder,
@@ -23,6 +24,11 @@ import {
 import { truncateString } from '../../utils/components.js';
 import { ERROR_MESSAGES } from '../../utils/constants.js';
 
+const FinkiUrlSchema = z.url().refine((value) => {
+  const url = new URL(value);
+
+  return url.protocol === 'https:' && url.hostname === 'finki.ukim.mk';
+}, 'Expected an HTTPS finki.ukim.mk URL');
 const RenderedSchema = z.object({ rendered: z.string() });
 const WordPressItemSchema = z.object({
   _embedded: z
@@ -31,7 +37,7 @@ const WordPressItemSchema = z.object({
         .array(
           z.object({
             // eslint-disable-next-line camelcase -- WordPress REST API field name
-            source_url: z.url(),
+            source_url: FinkiUrlSchema,
           }),
         )
         .optional(),
@@ -39,7 +45,7 @@ const WordPressItemSchema = z.object({
     .optional(),
   content: RenderedSchema.optional(),
   id: z.number().int(),
-  link: z.url(),
+  link: FinkiUrlSchema,
   title: RenderedSchema,
 });
 const WordPressItemsSchema = z.array(WordPressItemSchema);
@@ -83,7 +89,7 @@ export abstract class WordPressStrategy implements ScraperStrategy {
   }
 
   protected getPostData(item: WordPressItem): PostData {
-    const title = truncateString(this.getTitle(item));
+    const title = escapeMarkdown(truncateString(this.getTitle(item)));
     const textDisplayComponents = [
       new TextDisplayBuilder().setContent(
         this.includeContent
@@ -96,7 +102,9 @@ export abstract class WordPressStrategy implements ScraperStrategy {
       const content = plainText(item.content?.rendered ?? '');
       textDisplayComponents.push(
         new TextDisplayBuilder().setContent(
-          content === '' ? 'Нема опис.' : truncateString(content),
+          content === ''
+            ? 'Нема опис.'
+            : escapeMarkdown(truncateString(content)),
         ),
       );
     }
@@ -144,6 +152,10 @@ export abstract class WordPressStrategy implements ScraperStrategy {
       if (pageItems.length < pageSize) {
         break;
       }
+    }
+
+    if (items.length === 0) {
+      throw new Error(ERROR_MESSAGES.postsNotFound);
     }
 
     return items;

--- a/src/strategies/base/WordPressStrategy.ts
+++ b/src/strategies/base/WordPressStrategy.ts
@@ -14,7 +14,12 @@ import type {
   StrategyResult,
 } from '../../lib/Scraper.js';
 
-import { getSeenPostIds, markPostsSeen } from '../../utils/cache.js';
+import {
+  getSeenPostIds,
+  getSnapshot,
+  markPostsSeen,
+  setSnapshot,
+} from '../../utils/cache.js';
 import { truncateString } from '../../utils/components.js';
 import { ERROR_MESSAGES } from '../../utils/constants.js';
 
@@ -43,6 +48,7 @@ type WordPressItem = z.infer<typeof WordPressItemSchema>;
 
 const API_BASE_URL = 'https://finki.ukim.mk/wp-json/wp/v2';
 const MAX_PAGE_SIZE = 100;
+const MIGRATION_SNAPSHOT_KEY = 'wordpress-rest-migrated';
 
 const plainText = (html: string): string =>
   cheerio.load(html).root().text().replaceAll(/\s+/gu, ' ').trim();
@@ -55,19 +61,21 @@ export abstract class WordPressStrategy implements ScraperStrategy {
   public async getChanges(context: StrategyContext): Promise<StrategyResult> {
     const items = await this.fetchItems(context.maxPosts);
     const seenIds = getSeenPostIds(context.scraperId);
-    const ids = items.map(({ link }) => link);
-    const hasCanonicalIds = ids.some((id) => seenIds.has(id));
+    const ids = items.map((item) => this.getId(item));
+    const isMigrated =
+      getSnapshot(context.scraperId, MIGRATION_SNAPSHOT_KEY) === '1';
     const posts =
-      seenIds.size > 0 && !hasCanonicalIds
+      seenIds.size > 0 && !isMigrated
         ? []
         : items
-            .filter((item) => !seenIds.has(item.link))
+            .filter((item) => !seenIds.has(this.getId(item)))
             .toReversed()
             .map((item) => this.getPostData(item));
 
     return {
       commit: () => {
         markPostsSeen(context.scraperId, ids);
+        setSnapshot(context.scraperId, MIGRATION_SNAPSHOT_KEY, '1');
       },
       itemsFound: items.length,
       posts,
@@ -106,17 +114,16 @@ export abstract class WordPressStrategy implements ScraperStrategy {
                 .addTextDisplayComponents(textDisplayComponents)
                 .setThumbnailAccessory((thumbnail) => thumbnail.setURL(image)),
             ),
-      id: item.link,
+      id: this.getId(item),
     };
   }
 
   private async fetchItems(maxPosts: number): Promise<WordPressItem[]> {
     const items: WordPressItem[] = [];
-    let page = 1;
 
     while (items.length < maxPosts) {
       const pageSize = Math.min(MAX_PAGE_SIZE, maxPosts - items.length);
-      const url = `${API_BASE_URL}/${this.collection}?per_page=${pageSize}&page=${page}&_embed=1`;
+      const url = `${API_BASE_URL}/${this.collection}?per_page=${pageSize}&offset=${items.length}&_embed=1`;
       let response: Response;
 
       try {
@@ -137,11 +144,13 @@ export abstract class WordPressStrategy implements ScraperStrategy {
       if (pageItems.length < pageSize) {
         break;
       }
-
-      page += 1;
     }
 
     return items;
+  }
+
+  private getId(item: WordPressItem): string {
+    return `wordpress:${this.collection}:${item.id}`;
   }
 
   private getTitle(item: WordPressItem): string {

--- a/src/strategies/base/WordPressStrategy.ts
+++ b/src/strategies/base/WordPressStrategy.ts
@@ -24,11 +24,20 @@ import {
 import { truncateString } from '../../utils/components.js';
 import { ERROR_MESSAGES } from '../../utils/constants.js';
 
-const FinkiUrlSchema = z.url().refine((value) => {
-  const url = new URL(value);
-
-  return url.protocol === 'https:' && url.hostname === 'finki.ukim.mk';
-}, 'Expected an HTTPS finki.ukim.mk URL');
+const FinkiUrlSchema = z
+  .url()
+  .transform((value) => new URL(value))
+  .refine(
+    (url) => url.protocol === 'https:' && url.hostname === 'finki.ukim.mk',
+    'Expected an HTTPS finki.ukim.mk URL',
+  )
+  .transform((url) =>
+    url.href
+      .replaceAll('(', '%28')
+      .replaceAll(')', '%29')
+      .replaceAll('[', '%5B')
+      .replaceAll(']', '%5D'),
+  );
 const RenderedSchema = z.object({ rendered: z.string() });
 const WordPressItemSchema = z.object({
   _embedded: z
@@ -58,6 +67,21 @@ const MIGRATION_SNAPSHOT_KEY = 'wordpress-rest-migrated';
 
 const plainText = (html: string): string =>
   cheerio.load(html).root().text().replaceAll(/\s+/gu, ' ').trim();
+
+const escapeDiscordText = (text: string): string =>
+  escapeMarkdown(
+    text
+      .replaceAll('[', '［')
+      .replaceAll(']', '］')
+      .replaceAll('(', '（')
+      .replaceAll(')', '）'),
+    {
+      bulletedList: true,
+      heading: true,
+      maskedLink: true,
+      numberedList: true,
+    },
+  ).replaceAll('@', '@\u{200B}');
 
 export abstract class WordPressStrategy implements ScraperStrategy {
   public abstract collection: string;
@@ -89,7 +113,7 @@ export abstract class WordPressStrategy implements ScraperStrategy {
   }
 
   protected getPostData(item: WordPressItem): PostData {
-    const title = escapeMarkdown(truncateString(this.getTitle(item)));
+    const title = escapeDiscordText(truncateString(this.getTitle(item)));
     const textDisplayComponents = [
       new TextDisplayBuilder().setContent(
         this.includeContent
@@ -104,7 +128,7 @@ export abstract class WordPressStrategy implements ScraperStrategy {
         new TextDisplayBuilder().setContent(
           content === ''
             ? 'Нема опис.'
-            : escapeMarkdown(truncateString(content)),
+            : escapeDiscordText(truncateString(content)),
         ),
       );
     }

--- a/src/strategies/base/WordPressStrategy.ts
+++ b/src/strategies/base/WordPressStrategy.ts
@@ -1,0 +1,150 @@
+import * as cheerio from 'cheerio';
+import {
+  ContainerBuilder,
+  heading,
+  hyperlink,
+  TextDisplayBuilder,
+} from 'discord.js';
+import { z } from 'zod';
+
+import type { PostData } from '../../lib/Post.js';
+import type {
+  ScraperStrategy,
+  StrategyContext,
+  StrategyResult,
+} from '../../lib/Scraper.js';
+
+import { getSeenPostIds, markPostsSeen } from '../../utils/cache.js';
+import { truncateString } from '../../utils/components.js';
+import { ERROR_MESSAGES } from '../../utils/constants.js';
+
+const RenderedSchema = z.object({ rendered: z.string() });
+const WordPressItemSchema = z.object({
+  _embedded: z
+    .object({
+      'wp:featuredmedia': z
+        .array(
+          z.object({
+            // eslint-disable-next-line camelcase -- WordPress REST API field name
+            source_url: z.url(),
+          }),
+        )
+        .optional(),
+    })
+    .optional(),
+  content: RenderedSchema.optional(),
+  id: z.number().int(),
+  link: z.url(),
+  title: RenderedSchema,
+});
+const WordPressItemsSchema = z.array(WordPressItemSchema);
+
+type WordPressItem = z.infer<typeof WordPressItemSchema>;
+
+const API_BASE_URL = 'https://finki.ukim.mk/wp-json/wp/v2';
+const MAX_PAGE_SIZE = 100;
+
+const plainText = (html: string): string =>
+  cheerio.load(html).root().text().replaceAll(/\s+/gu, ' ').trim();
+
+export abstract class WordPressStrategy implements ScraperStrategy {
+  public abstract collection: string;
+
+  public includeContent = true;
+
+  public async getChanges(context: StrategyContext): Promise<StrategyResult> {
+    const items = await this.fetchItems(context.maxPosts);
+    const seenIds = getSeenPostIds(context.scraperId);
+    const ids = items.map(({ link }) => link);
+    const hasCanonicalIds = ids.some((id) => seenIds.has(id));
+    const posts =
+      seenIds.size > 0 && !hasCanonicalIds
+        ? []
+        : items
+            .filter((item) => !seenIds.has(item.link))
+            .toReversed()
+            .map((item) => this.getPostData(item));
+
+    return {
+      commit: () => {
+        markPostsSeen(context.scraperId, ids);
+      },
+      itemsFound: items.length,
+      posts,
+    };
+  }
+
+  protected getPostData(item: WordPressItem): PostData {
+    const title = truncateString(this.getTitle(item));
+    const textDisplayComponents = [
+      new TextDisplayBuilder().setContent(
+        this.includeContent
+          ? heading(hyperlink(title, item.link), 3)
+          : heading(hyperlink(title, item.link), 2),
+      ),
+    ];
+
+    if (this.includeContent) {
+      const content = plainText(item.content?.rendered ?? '');
+      textDisplayComponents.push(
+        new TextDisplayBuilder().setContent(
+          content === '' ? 'Нема опис.' : truncateString(content),
+        ),
+      );
+    }
+
+    const image = item._embedded?.['wp:featuredmedia']?.[0]?.source_url;
+
+    return {
+      component:
+        image === undefined
+          ? new ContainerBuilder().addTextDisplayComponents(
+              textDisplayComponents,
+            )
+          : new ContainerBuilder().addSectionComponents((section) =>
+              section
+                .addTextDisplayComponents(textDisplayComponents)
+                .setThumbnailAccessory((thumbnail) => thumbnail.setURL(image)),
+            ),
+      id: item.link,
+    };
+  }
+
+  private async fetchItems(maxPosts: number): Promise<WordPressItem[]> {
+    const items: WordPressItem[] = [];
+    let page = 1;
+
+    while (items.length < maxPosts) {
+      const pageSize = Math.min(MAX_PAGE_SIZE, maxPosts - items.length);
+      const url = `${API_BASE_URL}/${this.collection}?per_page=${pageSize}&page=${page}&_embed=1`;
+      let response: Response;
+
+      try {
+        response = await fetch(url);
+      } catch (error) {
+        throw new Error(ERROR_MESSAGES.fetchFailed, { cause: error });
+      }
+
+      if (!response.ok) {
+        throw new Error(
+          `${ERROR_MESSAGES.badResponseCode}: ${response.status}`,
+        );
+      }
+
+      const pageItems = WordPressItemsSchema.parse(await response.json());
+      items.push(...pageItems);
+
+      if (pageItems.length < pageSize) {
+        break;
+      }
+
+      page += 1;
+    }
+
+    return items;
+  }
+
+  private getTitle(item: WordPressItem): string {
+    return plainText(item.title.rendered) || '?';
+  }
+}

--- a/test/scraper-delivery.test.ts
+++ b/test/scraper-delivery.test.ts
@@ -107,3 +107,63 @@ test('does not mark posts seen when webhook delivery fails', async () => {
   await expect(scraper.run()).rejects.toThrow(stopScraperRegex);
   expect(commitCalls).toStrictEqual([]);
 });
+
+test('commits cache migration when a strategy suppresses all posts', async () => {
+  const commit = vi.fn<() => void>();
+
+  vi.doMock('discord.js', () => ({
+    codeBlock: (value: string) => `\`\`\`\n${value}\n\`\`\``,
+    MessageFlagsBitField: { Flags: { IsComponentsV2: 32_768 } },
+    roleMention: (roleId: string) => `<@&${roleId}>`,
+    TextDisplayBuilder: class TextDisplayBuilder {
+      public toJSON() {
+        return { type: 10 };
+      }
+    },
+    WebhookClient: class WebhookClient {
+      public send(): Promise<void> {
+        return Promise.resolve();
+      }
+    },
+  }));
+  vi.doMock('../src/configuration/config.js', () => ({
+    getConfigProperty: (property: string) => {
+      const config: Record<string, unknown> = {
+        errorDelay: 1,
+        errorWebhook: '',
+        maxPosts: 20,
+        scrapers: {
+          migration: {
+            link: 'https://finki.ukim.mk/wp-json/wp/v2/announcement',
+            strategy: 'migration',
+          },
+        },
+        sendPosts: true,
+        successDelay: 1,
+        webhook: '',
+      };
+
+      return config[property];
+    },
+  }));
+  vi.doMock('../src/utils/logger.js', () => ({
+    logger: {
+      error: vi.fn<(...args: unknown[]) => void>(),
+      info: vi.fn<(...args: unknown[]) => void>(),
+    },
+  }));
+  vi.doMock('../src/utils/strategies.js', () => ({
+    createStrategy: () => ({
+      getChanges: (): Promise<StrategyResult> =>
+        Promise.resolve({ commit, itemsFound: 20, posts: [] }),
+    }),
+  }));
+  vi.doMock('../src/utils/webhooks.js', () => ({ errorWebhook: undefined }));
+
+  const { Scraper } = await import('../src/Scraper.js');
+  vi.spyOn(Scraper, 'sleep').mockRejectedValue(new Error('stop scraper'));
+  const scraper = new Scraper('migration');
+
+  await expect(scraper.run()).rejects.toThrow(stopScraperRegex);
+  expect(commit).toHaveBeenCalledOnce();
+});

--- a/test/strategies.test.ts
+++ b/test/strategies.test.ts
@@ -160,7 +160,7 @@ describe('CourseStrategy', () => {
 });
 
 describe('TimetablesStrategy', () => {
-  it('collapses ID whitespace and normalizes relative links', async () => {
+  it('uses the WordPress schedule collection without content previews', async () => {
     vi.doMock(configModulePath, () => ({
       getConfigProperty: () => {},
     }));
@@ -168,17 +168,10 @@ describe('TimetablesStrategy', () => {
     const { TimetablesStrategy } =
       await import('../src/strategies/TimetablesStrategy.js');
     const strategy = new TimetablesStrategy();
-    const $element = loadElement(
-      '<div><a href="documents/schedule.pdf"> Summer \n timetable </a></div>',
-      'div',
-    );
-    const post = strategy.getPostData($element);
-    const strings = collectStrings(post.component.toJSON()).join('\n');
 
-    expect(strategy.getId($element)).toBe('Summer timetable');
-    expect(post.id).toBe('Summer timetable');
-    expect(strings).toContain('Summer timetable');
-    expect(strings).toContain('https://finki.ukim.mk/documents/schedule.pdf');
+    expect(strategy.collection).toBe('schedule');
+    // eslint-disable-next-line vitest/prefer-to-be-falsy -- assert the exact public option value
+    expect(strategy.includeContent).toBe(false);
   });
 });
 
@@ -245,29 +238,29 @@ describe('InternshipsStrategy', () => {
   });
 });
 
-describe('JobsStrategy, EventsStrategy, and ProjectsStrategy', () => {
+describe('WordPress content strategies', () => {
   it.each([
     {
+      collection: 'jobs-and-internships',
       exportName: 'JobsStrategy',
       modulePath: '../src/strategies/JobsStrategy.js',
       name: 'jobs',
-      selector: 'div.views-row',
     },
     {
+      collection: 'event',
       exportName: 'EventsStrategy',
       modulePath: '../src/strategies/EventsStrategy.js',
       name: 'events',
-      selector: 'div.news-item',
     },
     {
+      collection: 'project',
       exportName: 'ProjectsStrategy',
       modulePath: '../src/strategies/ProjectsStrategy.js',
       name: 'projects',
-      selector: 'div.news-item',
     },
   ])(
-    'parses $name cards with image thumbnails',
-    async ({ exportName, modulePath, selector }) => {
+    'maps $name to its WordPress collection and legacy selector',
+    async ({ collection, exportName, modulePath }) => {
       vi.doMock(configModulePath, () => ({
         getConfigProperty: () => {},
       }));
@@ -275,10 +268,7 @@ describe('JobsStrategy, EventsStrategy, and ProjectsStrategy', () => {
       const strategyModule = (await import(modulePath)) as Record<
         string,
         new () => {
-          getPostData: ($element: Cheerio<Element>) => {
-            component: { toJSON: () => unknown };
-            id: null | string;
-          };
+          collection: string;
         }
       >;
       const StrategyClass = strategyModule[exportName];
@@ -288,24 +278,8 @@ describe('JobsStrategy, EventsStrategy, and ProjectsStrategy', () => {
       }
 
       const strategy = new StrategyClass();
-      const $element = loadElement(
-        `
-        <div class="${selector.replace('div.', '')}">
-          <a href="/ignored">Ignored</a><a href="/mk/item">Important title</a>
-          <div class="col-xs-12 col-sm-8"><div class="field-content">Important content</div></div>
-          <img src="https://finki.ukim.mk/image.png?itok=abc" />
-        </div>
-      `,
-        'div',
-      );
-      const post = strategy.getPostData($element);
-      const strings = collectStrings(post.component.toJSON()).join('\n');
 
-      expect(post.id).toBe('https://finki.ukim.mk/mk/item');
-      expect(strings).toContain('Important title');
-      expect(strings).toContain('https://finki.ukim.mk/mk/item');
-      expect(strings).toContain('Important content');
-      expect(strings).toContain('https://finki.ukim.mk/image.png');
+      expect(strategy.collection).toBe(collection);
     },
   );
 });

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -170,21 +170,25 @@ describe('configuration schemas', () => {
 
 describe('createStrategy', () => {
   it.each([
-    [Strategy.Activities, 'li.activity'],
-    [Strategy.Announcements, 'div.views-row'],
-    [Strategy.Course, 'article'],
-    [Strategy.Diplomas, 'div.panel'],
-    [Strategy.Events, 'div.news-item'],
-    [Strategy.Example, 'Selector for all data containers'],
-    [Strategy.Internships, 'div.container div.row > div.col > div.card'],
-    [Strategy.Jobs, 'div.views-row'],
-    [Strategy.Masters, 'div.row.rounded'],
-    [Strategy.Partners, 'div.card, div.support'],
-    [Strategy.Projects, 'div.news-item'],
-    [Strategy.Timetables, 'div.col-sm-11'],
+    [Strategy.Activities, 'postsSelector', 'li.activity'],
+    [Strategy.Announcements, 'collection', 'announcement'],
+    [Strategy.Course, 'postsSelector', 'article'],
+    [Strategy.Diplomas, 'postsSelector', 'div.panel'],
+    [Strategy.Events, 'collection', 'event'],
+    [Strategy.Example, 'postsSelector', 'Selector for all data containers'],
+    [
+      Strategy.Internships,
+      'postsSelector',
+      'div.container div.row > div.col > div.card',
+    ],
+    [Strategy.Jobs, 'collection', 'jobs-and-internships'],
+    [Strategy.Masters, 'postsSelector', 'div.row.rounded'],
+    [Strategy.Partners, 'postsSelector', 'div.card, div.support'],
+    [Strategy.Projects, 'collection', 'project'],
+    [Strategy.Timetables, 'collection', 'schedule'],
   ])(
     'returns a strategy instance for %s',
-    async (strategyName, postsSelector) => {
+    async (strategyName, property, expectedValue) => {
       vi.doMock('../src/configuration/config.js', () => ({
         getConfigProperty: () => {},
       }));
@@ -192,7 +196,7 @@ describe('createStrategy', () => {
       const { createStrategy } = await import('../src/utils/strategies.js');
       const strategy = createStrategy(strategyName);
 
-      expect(strategy).toHaveProperty('postsSelector', postsSelector);
+      expect(strategy).toHaveProperty(property, expectedValue);
     },
   );
 

--- a/test/wordpress-strategy.test.ts
+++ b/test/wordpress-strategy.test.ts
@@ -268,6 +268,59 @@ describe('WordPress strategies', () => {
     ).rejects.toThrow('Failed to fetch');
   });
 
+  it('does not finalize migration from an empty WordPress collection', async () => {
+    cacheMocks.getSeenPostIds.mockReturnValue(
+      new Set(['https://finki.ukim.mk/mk/content/legacy']),
+    );
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(Response.json([]));
+    const { JobsStrategy } = await import('../src/strategies/JobsStrategy.js');
+    const strategy = new JobsStrategy();
+
+    await expect(
+      strategy.getChanges({
+        cookie: undefined,
+        link: 'ignored',
+        maxPosts: 5,
+        scraperId: 'jobs',
+      }),
+    ).rejects.toThrow('Posts not found');
+    expect(cacheMocks.markPostsSeen).not.toHaveBeenCalled();
+    expect(cacheMocks.setSnapshot).not.toHaveBeenCalled();
+  });
+
+  it('rejects external WordPress post and media URLs', async () => {
+    cacheMocks.getSeenPostIds.mockReturnValue(new Set());
+    const { JobsStrategy } = await import('../src/strategies/JobsStrategy.js');
+    const strategy = new JobsStrategy();
+
+    for (const item of [
+      createApiItem({ link: 'https://evil.example/phishing' }),
+      createApiItem({
+        _embedded: {
+          'wp:featuredmedia': [
+            {
+              // eslint-disable-next-line camelcase -- WordPress REST API fixture field
+              source_url: 'https://evil.example/image.png',
+            },
+          ],
+        },
+      }),
+    ]) {
+      vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+        Response.json([item]),
+      );
+
+      await expect(
+        strategy.getChanges({
+          cookie: undefined,
+          link: 'ignored',
+          maxPosts: 5,
+          scraperId: 'jobs',
+        }),
+      ).rejects.toThrow('Expected an HTTPS finki.ukim.mk URL');
+    }
+  });
+
   it('renders WordPress HTML as plain Discord text with featured media', async () => {
     cacheMocks.getSeenPostIds.mockReturnValue(new Set());
     vi.spyOn(globalThis, 'fetch').mockResolvedValue(

--- a/test/wordpress-strategy.test.ts
+++ b/test/wordpress-strategy.test.ts
@@ -1,0 +1,223 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const cacheMocks = vi.hoisted(() => ({
+  getSeenPostIds: vi.fn<(scraperId: string) => Set<string>>(),
+  markPostsSeen:
+    vi.fn<(scraperId: string, postIds: Array<null | string>) => void>(),
+}));
+
+vi.mock('../src/utils/cache.js', () => cacheMocks);
+vi.mock('../src/configuration/config.js', () => ({
+  getConfigProperty: vi.fn<() => undefined>(),
+}));
+
+const createApiItem = (overrides: Record<string, unknown> = {}) => ({
+  _embedded: {
+    'wp:featuredmedia': [
+      {
+        // eslint-disable-next-line camelcase -- WordPress REST API fixture field
+        source_url: 'https://finki.ukim.mk/wp-content/uploads/item.jpg',
+      },
+    ],
+  },
+  content: { rendered: '<p>Current <strong>description</strong>.</p>' },
+  id: 42,
+  link: 'https://finki.ukim.mk/jobs-and-internships/current-item/',
+  title: { rendered: 'Current &amp; item' },
+  ...overrides,
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  cacheMocks.getSeenPostIds.mockReset();
+  cacheMocks.markPostsSeen.mockReset();
+});
+
+describe('WordPress strategies', () => {
+  it.each([
+    ['announcements', 'announcement'],
+    ['jobs', 'jobs-and-internships'],
+    ['events', 'event'],
+    ['projects', 'project'],
+    ['timetables', 'schedule'],
+  ])(
+    'fetches the %s collection instead of the configured legacy page',
+    async (strategyName, collection) => {
+      cacheMocks.getSeenPostIds.mockReturnValue(new Set());
+      const fetchMock = vi
+        .spyOn(globalThis, 'fetch')
+        .mockResolvedValue(Response.json([createApiItem()]));
+      const { createStrategy } = await import('../src/utils/strategies.js');
+      const strategy = createStrategy(strategyName) as {
+        getChanges: (context: {
+          cookie: undefined;
+          link: string;
+          maxPosts: number;
+          scraperId: string;
+        }) => Promise<{
+          commit: () => void;
+          itemsFound?: number;
+          posts: unknown[];
+        }>;
+      };
+
+      const result = await strategy.getChanges({
+        cookie: undefined,
+        link: 'https://oldsite.invalid/legacy-listing',
+        maxPosts: 5,
+        scraperId: collection,
+      });
+
+      expect(fetchMock).toHaveBeenCalledExactlyOnceWith(
+        `https://finki.ukim.mk/wp-json/wp/v2/${collection}?per_page=5&page=1&_embed=1`,
+      );
+      expect(result.itemsFound).toBe(1);
+      expect(result.posts).toHaveLength(1);
+
+      result.commit();
+
+      expect(cacheMocks.markPostsSeen).toHaveBeenCalledWith(collection, [
+        'https://finki.ukim.mk/jobs-and-internships/current-item/',
+      ]);
+    },
+  );
+
+  it('preserves legacy cache identity while committing the canonical WordPress ID', async () => {
+    const legacyId = 'https://finki.ukim.mk/mk/content/current-item';
+    cacheMocks.getSeenPostIds.mockReturnValue(new Set([legacyId]));
+    const fetchMock = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValue(Response.json([createApiItem()]));
+    const { JobsStrategy } = await import('../src/strategies/JobsStrategy.js');
+    const strategy = new JobsStrategy();
+
+    const result = await strategy.getChanges({
+      cookie: undefined,
+      link: 'https://oldsite.invalid/legacy-listing',
+      maxPosts: 5,
+      scraperId: 'jobs',
+    });
+
+    expect(result.posts).toHaveLength(0);
+    expect(fetchMock).toHaveBeenCalledOnce();
+
+    result.commit();
+
+    expect(cacheMocks.markPostsSeen).toHaveBeenCalledWith('jobs', [
+      'https://finki.ukim.mk/jobs-and-internships/current-item/',
+    ]);
+  });
+
+  it('continues normally after canonical WordPress IDs are seeded', async () => {
+    const canonicalId =
+      'https://finki.ukim.mk/jobs-and-internships/current-item/';
+    cacheMocks.getSeenPostIds.mockReturnValue(
+      new Set([canonicalId, 'https://finki.ukim.mk/mk/content/legacy']),
+    );
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      Response.json([
+        createApiItem(),
+        createApiItem({
+          id: 43,
+          link: 'https://finki.ukim.mk/jobs-and-internships/new-item/',
+          title: { rendered: 'New item' },
+        }),
+      ]),
+    );
+    const { JobsStrategy } = await import('../src/strategies/JobsStrategy.js');
+    const strategy = new JobsStrategy();
+
+    const result = await strategy.getChanges({
+      cookie: undefined,
+      link: 'ignored',
+      maxPosts: 5,
+      scraperId: 'jobs',
+    });
+
+    expect(result.posts).toHaveLength(1);
+    expect(result.posts[0]?.id).toBe(
+      'https://finki.ukim.mk/jobs-and-internships/new-item/',
+    );
+  });
+
+  it('paginates WordPress requests above the collection page limit', async () => {
+    cacheMocks.getSeenPostIds.mockReturnValue(new Set());
+    const firstPage = Array.from({ length: 100 }, (_, index) =>
+      createApiItem({
+        id: index,
+        link: `https://finki.ukim.mk/jobs-and-internships/item-${index}/`,
+      }),
+    );
+    const fetchMock = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(Response.json(firstPage))
+      .mockResolvedValueOnce(
+        Response.json([
+          createApiItem({
+            id: 101,
+            link: 'https://finki.ukim.mk/jobs-and-internships/item-101/',
+          }),
+        ]),
+      );
+    const { JobsStrategy } = await import('../src/strategies/JobsStrategy.js');
+    const strategy = new JobsStrategy();
+
+    const result = await strategy.getChanges({
+      cookie: undefined,
+      link: 'ignored',
+      maxPosts: 101,
+      scraperId: 'jobs',
+    });
+
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      1,
+      'https://finki.ukim.mk/wp-json/wp/v2/jobs-and-internships?per_page=100&page=1&_embed=1',
+    );
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      2,
+      'https://finki.ukim.mk/wp-json/wp/v2/jobs-and-internships?per_page=1&page=2&_embed=1',
+    );
+    expect(result.itemsFound).toBe(101);
+  });
+
+  it('renders WordPress HTML as plain Discord text with featured media', async () => {
+    cacheMocks.getSeenPostIds.mockReturnValue(new Set());
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      Response.json([createApiItem()]),
+    );
+    const { JobsStrategy } = await import('../src/strategies/JobsStrategy.js');
+    const strategy = new JobsStrategy();
+
+    const result = await strategy.getChanges({
+      cookie: undefined,
+      link: 'ignored',
+      maxPosts: 5,
+      scraperId: 'jobs',
+    });
+    const serialized = JSON.stringify(result.posts[0]);
+
+    expect(serialized).toContain('Current & item');
+    expect(serialized).toContain('Current description.');
+    expect(serialized).toContain(
+      'https://finki.ukim.mk/wp-content/uploads/item.jpg',
+    );
+  });
+
+  it('rejects malformed WordPress responses instead of treating them as no changes', async () => {
+    cacheMocks.getSeenPostIds.mockReturnValue(new Set());
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      Response.json([{ id: 42 }]),
+    );
+    const { JobsStrategy } = await import('../src/strategies/JobsStrategy.js');
+    const strategy = new JobsStrategy();
+
+    await expect(
+      strategy.getChanges({
+        cookie: undefined,
+        link: 'ignored',
+        maxPosts: 5,
+        scraperId: 'jobs',
+      }),
+    ).rejects.toThrow('Invalid input');
+  });
+});

--- a/test/wordpress-strategy.test.ts
+++ b/test/wordpress-strategy.test.ts
@@ -321,6 +321,40 @@ describe('WordPress strategies', () => {
     }
   });
 
+  it('neutralizes Discord Markdown breakout payloads', async () => {
+    cacheMocks.getSeenPostIds.mockReturnValue(new Set());
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      Response.json([
+        createApiItem({
+          content: {
+            rendered:
+              '<p>[FINKI Login](https://evil.example/phish) @everyone</p>',
+          },
+          link: 'https://finki.ukim.mk/) [Login](https://evil.example/phish',
+          title: {
+            rendered: 'Trusted](https://evil.example/phish)[label',
+          },
+        }),
+      ]),
+    );
+    const { JobsStrategy } = await import('../src/strategies/JobsStrategy.js');
+    const strategy = new JobsStrategy();
+
+    const result = await strategy.getChanges({
+      cookie: undefined,
+      link: 'ignored',
+      maxPosts: 5,
+      scraperId: 'jobs',
+    });
+    const serialized = JSON.stringify(result.posts[0]);
+
+    expect(serialized).not.toContain('](https://evil.example');
+    expect(serialized).not.toContain('@everyone');
+    expect(serialized).toContain(
+      '%29%20%5BLogin%5D%28https://evil.example/phish',
+    );
+  });
+
   it('renders WordPress HTML as plain Discord text with featured media', async () => {
     cacheMocks.getSeenPostIds.mockReturnValue(new Set());
     vi.spyOn(globalThis, 'fetch').mockResolvedValue(

--- a/test/wordpress-strategy.test.ts
+++ b/test/wordpress-strategy.test.ts
@@ -2,8 +2,10 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 
 const cacheMocks = vi.hoisted(() => ({
   getSeenPostIds: vi.fn<(scraperId: string) => Set<string>>(),
+  getSnapshot: vi.fn<(scraperId: string, key: string) => string | undefined>(),
   markPostsSeen:
     vi.fn<(scraperId: string, postIds: Array<null | string>) => void>(),
+  setSnapshot: vi.fn<(scraperId: string, key: string, value: string) => void>(),
 }));
 
 vi.mock('../src/utils/cache.js', () => cacheMocks);
@@ -30,7 +32,9 @@ const createApiItem = (overrides: Record<string, unknown> = {}) => ({
 afterEach(() => {
   vi.restoreAllMocks();
   cacheMocks.getSeenPostIds.mockReset();
+  cacheMocks.getSnapshot.mockReset();
   cacheMocks.markPostsSeen.mockReset();
+  cacheMocks.setSnapshot.mockReset();
 });
 
 describe('WordPress strategies', () => {
@@ -69,7 +73,7 @@ describe('WordPress strategies', () => {
       });
 
       expect(fetchMock).toHaveBeenCalledExactlyOnceWith(
-        `https://finki.ukim.mk/wp-json/wp/v2/${collection}?per_page=5&page=1&_embed=1`,
+        `https://finki.ukim.mk/wp-json/wp/v2/${collection}?per_page=5&offset=0&_embed=1`,
       );
       expect(result.itemsFound).toBe(1);
       expect(result.posts).toHaveLength(1);
@@ -77,8 +81,13 @@ describe('WordPress strategies', () => {
       result.commit();
 
       expect(cacheMocks.markPostsSeen).toHaveBeenCalledWith(collection, [
-        'https://finki.ukim.mk/jobs-and-internships/current-item/',
+        `wordpress:${collection}:42`,
       ]);
+      expect(cacheMocks.setSnapshot).toHaveBeenCalledWith(
+        collection,
+        'wordpress-rest-migrated',
+        '1',
+      );
     },
   );
 
@@ -104,16 +113,16 @@ describe('WordPress strategies', () => {
     result.commit();
 
     expect(cacheMocks.markPostsSeen).toHaveBeenCalledWith('jobs', [
-      'https://finki.ukim.mk/jobs-and-internships/current-item/',
+      'wordpress:jobs-and-internships:42',
     ]);
   });
 
   it('continues normally after canonical WordPress IDs are seeded', async () => {
-    const canonicalId =
-      'https://finki.ukim.mk/jobs-and-internships/current-item/';
+    const canonicalId = 'wordpress:jobs-and-internships:42';
     cacheMocks.getSeenPostIds.mockReturnValue(
       new Set([canonicalId, 'https://finki.ukim.mk/mk/content/legacy']),
     );
+    cacheMocks.getSnapshot.mockReturnValue('1');
     vi.spyOn(globalThis, 'fetch').mockResolvedValue(
       Response.json([
         createApiItem(),
@@ -135,9 +144,28 @@ describe('WordPress strategies', () => {
     });
 
     expect(result.posts).toHaveLength(1);
-    expect(result.posts[0]?.id).toBe(
-      'https://finki.ukim.mk/jobs-and-internships/new-item/',
+    expect(result.posts[0]?.id).toBe('wordpress:jobs-and-internships:43');
+  });
+
+  it('delivers a disjoint window after migration is marked complete', async () => {
+    cacheMocks.getSeenPostIds.mockReturnValue(
+      new Set(['wordpress:jobs-and-internships:1']),
     );
+    cacheMocks.getSnapshot.mockReturnValue('1');
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      Response.json([createApiItem({ id: 42 }), createApiItem({ id: 43 })]),
+    );
+    const { JobsStrategy } = await import('../src/strategies/JobsStrategy.js');
+    const strategy = new JobsStrategy();
+
+    const result = await strategy.getChanges({
+      cookie: undefined,
+      link: 'ignored',
+      maxPosts: 5,
+      scraperId: 'jobs',
+    });
+
+    expect(result.posts).toHaveLength(2);
   });
 
   it('paginates WordPress requests above the collection page limit', async () => {
@@ -171,13 +199,73 @@ describe('WordPress strategies', () => {
 
     expect(fetchMock).toHaveBeenNthCalledWith(
       1,
-      'https://finki.ukim.mk/wp-json/wp/v2/jobs-and-internships?per_page=100&page=1&_embed=1',
+      'https://finki.ukim.mk/wp-json/wp/v2/jobs-and-internships?per_page=100&offset=0&_embed=1',
     );
     expect(fetchMock).toHaveBeenNthCalledWith(
       2,
-      'https://finki.ukim.mk/wp-json/wp/v2/jobs-and-internships?per_page=1&page=2&_embed=1',
+      'https://finki.ukim.mk/wp-json/wp/v2/jobs-and-internships?per_page=1&offset=100&_embed=1',
     );
     expect(result.itemsFound).toBe(101);
+    expect(new Set(result.posts.map(({ id }) => id)).size).toBe(101);
+  });
+
+  it('does not request another page when maxPosts is exactly one full page', async () => {
+    cacheMocks.getSeenPostIds.mockReturnValue(new Set());
+    const fetchMock = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValue(
+        Response.json(
+          Array.from({ length: 100 }, (_, index) =>
+            createApiItem({ id: index }),
+          ),
+        ),
+      );
+    const { JobsStrategy } = await import('../src/strategies/JobsStrategy.js');
+    const strategy = new JobsStrategy();
+
+    const result = await strategy.getChanges({
+      cookie: undefined,
+      link: 'ignored',
+      maxPosts: 100,
+      scraperId: 'jobs',
+    });
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+    expect(result.itemsFound).toBe(100);
+  });
+
+  it('reports non-success WordPress responses', async () => {
+    cacheMocks.getSeenPostIds.mockReturnValue(new Set());
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(null, { status: 503 }),
+    );
+    const { JobsStrategy } = await import('../src/strategies/JobsStrategy.js');
+    const strategy = new JobsStrategy();
+
+    await expect(
+      strategy.getChanges({
+        cookie: undefined,
+        link: 'ignored',
+        maxPosts: 5,
+        scraperId: 'jobs',
+      }),
+    ).rejects.toThrow('Bad response code: 503');
+  });
+
+  it('reports WordPress network failures', async () => {
+    cacheMocks.getSeenPostIds.mockReturnValue(new Set());
+    vi.spyOn(globalThis, 'fetch').mockRejectedValue(new Error('network down'));
+    const { JobsStrategy } = await import('../src/strategies/JobsStrategy.js');
+    const strategy = new JobsStrategy();
+
+    await expect(
+      strategy.getChanges({
+        cookie: undefined,
+        link: 'ignored',
+        maxPosts: 5,
+        scraperId: 'jobs',
+      }),
+    ).rejects.toThrow('Failed to fetch');
   });
 
   it('renders WordPress HTML as plain Discord text with featured media', async () => {


### PR DESCRIPTION
## Summary
- migrate announcements, jobs, events, projects, and timetables to dedicated WordPress REST collections
- preserve existing strategy names and seed canonical WordPress cache identities without replaying legacy posts
- add bounded offset pagination, response validation, and Discord Markdown/URL hardening
- update sample endpoints and regression coverage

## Verification
- npm test (74 tests)
- npm run check
- npm run lint (one non-blocking test-size warning)
- npm run build
- live validation against all five WordPress collections
- isolated cache migration and pagination QA